### PR TITLE
chore: configure source maps

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,5 +23,10 @@ const config = {
 
 export default (env, argv) => {
   config.mode = argv.mode;
+
+  if (argv.mode === 'development') {
+    config.devtool = 'source-map';
+  }
+
   return config;
 };


### PR DESCRIPTION
Source map стали генерироваться хуже, после того, как было добавлено разделение на production and development mods: https://github.com/artensevruk/toDoApp/commit/85bd44d04e40c167dd204df6bc80670ff07fc52e#diff-1fb26bc12ac780c7ad7325730ed09fc4c2c3d757c276c3dacc44bfe20faf166fR24 👀 

Webpack по-другому ставит некоторые настройки по-умолчанию в случае если webpack.config.js экспортирует функцию, а не готовый объект с конфигурацией.

Вот так это выглядит **до** изменений в этом PR 👎 
![Screenshot 2023-07-03 at 21 16 07](https://github.com/artensevruk/toDoApp/assets/4971527/d5343917-65f3-4b95-80db-a3b932571e99)

 Вот так **после** 👍 
![Screenshot 2023-07-03 at 21 23 46](https://github.com/artensevruk/toDoApp/assets/4971527/3297a107-f8d4-4c4b-ba49-29028bacae2a)


Тут подробнее про настройку source maps: https://webpack.js.org/configuration/devtool/ 👀 